### PR TITLE
implement startTracking method and needed REST patch methods

### DIFF
--- a/Mite/Curl/Curly.php
+++ b/Mite/Curl/Curly.php
@@ -205,6 +205,20 @@ class Curly
 
 		return $this->doRequest($options);
 	}
+	
+	public function patch(Array $params = array(), Array $options = array(), $url = false)
+	{
+		$url && $this->create($url);
+
+		if (count($params))
+		{
+			$this->setOption('POSTFIELDS', http_build_query($params, null, '&'));
+		}
+
+		$this->setMethod('patch');
+
+		return $this->doRequest($options);
+	}
 
 	/**
 	 * executes request and returns the response

--- a/Mite/Mite.php
+++ b/Mite/Mite.php
@@ -293,6 +293,31 @@ class Mite
 	}
 
 	/**
+	 * Start tracking
+	 *
+	 * @param int $id
+	 */
+	public function startTracking($id)
+	{
+        //PATCH /tracker/:id.json
+		try
+		{
+            
+			$response = $this->Resty->patch('/tracker/'.$id.'.json');
+
+			if ($this->Resty->getInfo('http_code') == '200') {
+				return $response;
+			}
+		}
+		catch(\Exception $e)
+		{
+			throw new MiteException('Entity couldn\'t be added ('.$e->getMessage().').');
+		}
+
+		return false;
+	}
+	
+	/**
 	 * Add entity
 	 *
 	 * @param string $endpoint

--- a/Mite/Rest/Resty.php
+++ b/Mite/Rest/Resty.php
@@ -113,6 +113,11 @@ class Resty
 	{
 		return $this->doRequest('delete', $uri, $params);
 	}
+	
+	public function patch($uri, Array $params = array())
+	{
+		return $this->doRequest('patch', $uri, $params);
+	}
 
 	public function put($uri, $params = array())
 	{


### PR DESCRIPTION
A startTracking method with the needed HTTP patch methods were created.
The startTracking method starts the tracking of an time entry via API.